### PR TITLE
Adding variable and corresponding code for diverting percentage of requests which coming to a slave towards the master

### DIFF
--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -140,3 +140,4 @@ backend replicas_async_backend
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
 {% endif %}
+

--- a/roles/confd/templates/haproxy.tmpl.j2
+++ b/roles/confd/templates/haproxy.tmpl.j2
@@ -25,6 +25,15 @@ listen stats
     stats enable
     stats uri /
 
+listen master
+{% if cluster_vip is defined and cluster_vip | length > 0 %}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
+{% else %}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.master }}
+{% endif %}
+    maxconn {{ haproxy_maxconn.master }}
+    default_backend master_backend
+
 backend master_backend
     option tcplog
     option httpchk OPTIONS /primary
@@ -39,14 +48,21 @@ backend master_backend
 {{end}}{% endraw %}
 {% endif %}
 
-listen master
+
+listen replicas
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.master }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas }}
 {% endif %}
-    maxconn {{ haproxy_maxconn.master }}
-    default_backend master_backend
+    maxconn {{ haproxy_maxconn.replica }}
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
+{% endif %}
+    default_backend replicas_backend
+{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
+    use_backend master_backend if divert_to_master
+{% endif %}
 
 backend replicas_backend
     option tcplog
@@ -63,17 +79,18 @@ backend replicas_backend
 {{end}}{% endraw %}
 {% endif %}
 
-listen replicas
+
+listen replicas_sync
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_sync }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_sync }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
 {% endif %}
-    default_backend replicas_backend
+    default_backend replicas_sync_backend
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     use_backend master_backend if divert_to_master
 {% endif %}
@@ -93,17 +110,18 @@ backend replicas_sync_backend
 {{end}}{% endraw %}
 {% endif %}
 
-listen replicas_sync
+
+listen replicas_async
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_sync }}
+    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_async }}
 {% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_sync }}
+    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_async }}
 {% endif %}
     maxconn {{ haproxy_maxconn.replica }}
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
 {% endif %}
-    default_backend replicas_sync_backend
+    default_backend replicas_async_backend
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     use_backend master_backend if divert_to_master
 {% endif %}
@@ -122,19 +140,3 @@ backend replicas_async_backend
 {% raw %}{{range gets "/members/*"}} server {{base .Key}} {{$data := json .Value}}{{base (replace (index (split $data.conn_url "/") 2) "@" "/" -1)}} check port {{index (split (index (split $data.api_url "/") 2) ":") 1}}
 {{end}}{% endraw %}
 {% endif %}
-
-listen replicas_async
-{% if cluster_vip is defined and cluster_vip | length > 0 %}
-    bind {{ cluster_vip }}:{{ haproxy_listen_port.replicas_async }}
-{% else %}
-    bind {{ hostvars[inventory_hostname]['inventory_hostname'] }}:{{ haproxy_listen_port.replicas_async }}
-{% endif %}
-    maxconn {{ haproxy_maxconn.replica }}
-{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
-    acl divert_to_master rand(100) lt {{ haproxy_divert_to_master }}
-{% endif %}
-    default_backend replicas_async_backend
-{% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
-    use_backend master_backend if divert_to_master
-{% endif %}
-

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -25,22 +25,6 @@ listen stats
     stats enable
     stats uri /
 
-backend master_backend
-    option tcplog
-    option httpchk OPTIONS /primary
-    http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
-{% if pgbouncer_install|bool %}
-  {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
-  {% endfor %}
-{% endif %}
-{% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
-  {% for host in groups['postgres_cluster'] %}
-server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
-  {% endfor %}
-{% endif %}
-
 listen master
 {% if cluster_vip is defined and cluster_vip | length > 0 %}
     bind {{ cluster_vip }}:{{ haproxy_listen_port.master }}
@@ -50,12 +34,11 @@ listen master
     maxconn {{ haproxy_maxconn.master }}
     default_backend master_backend
 
-backend replicas_backend
+backend master_backend
     option tcplog
-    option httpchk OPTIONS /replica
-    balance roundrobin
+    option httpchk OPTIONS /primary
     http-check expect status 200
-    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+    default-server inter 3s fastinter 1s fall 3 rise 4 on-marked-down shutdown-sessions
 {% if pgbouncer_install|bool %}
   {% for host in groups['postgres_cluster'] %}
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
@@ -82,9 +65,9 @@ listen replicas
     use_backend master_backend if divert_to_master
 {% endif %}
 
-backend replicas_sync_backend
+backend replicas_backend
     option tcplog
-    option httpchk OPTIONS /sync
+    option httpchk OPTIONS /replica
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -114,9 +97,9 @@ listen replicas_sync
     use_backend master_backend if divert_to_master
 {% endif %}
 
-backend replicas_async_backend
+backend replicas_sync_backend
     option tcplog
-    option httpchk OPTIONS /async
+    option httpchk OPTIONS /sync
     balance roundrobin
     http-check expect status 200
     default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
@@ -144,4 +127,21 @@ listen replicas_async
     default_backend replicas_async_backend
 {% if haproxy_divert_to_master is defined and haproxy_divert_to_master > 0 and haproxy_divert_to_master < 100 %}
     use_backend master_backend if divert_to_master
+{% endif %}
+
+backend replicas_async_backend
+    option tcplog
+    option httpchk OPTIONS /async
+    balance roundrobin
+    http-check expect status 200
+    default-server inter 3s fastinter 1s fall 3 rise 2 on-marked-down shutdown-sessions
+{% if pgbouncer_install|bool %}
+  {% for host in groups['postgres_cluster'] %}
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ pgbouncer_listen_port }} check port {{ patroni_restapi_port }}
+  {% endfor %}
+{% endif %}
+{% if ( pgbouncer_install is not defined ) or ( not pgbouncer_install|bool ) %}
+  {% for host in groups['postgres_cluster'] %}
+server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
+  {% endfor %}
 {% endif %}

--- a/roles/haproxy/templates/haproxy.cfg.j2
+++ b/roles/haproxy/templates/haproxy.cfg.j2
@@ -145,3 +145,4 @@ server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hos
 server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['inventory_hostname'] }}:{{ postgresql_port }} check port {{ patroni_restapi_port }}
   {% endfor %}
 {% endif %}
+


### PR DESCRIPTION
The pull request adding variable and corresponding code for diverting specified percentage of requests which coming into HAProxy to a slave port towards the master.

Necessity of the feature is questionable and discussionable. AFAIK there's no any direct profit to use routing of a part of reading queries to master instead of a slave.

**Changes**

* added `haproxy_divert_to_master` var into `vars/main.yml`

* setting `haproxy_divert_to_master` to 0 to avoid changes in ansible deployment result with default configuration the variable setted to value 0 (which disabling any diverting of connections to master instead of slave)

* added corresponding code into `haproxy.cfg.j2` template

* added corresponding code into `haproxy.tmpl.j2` template